### PR TITLE
Add workflow to update Go dep major versions

### DIFF
--- a/.github/raise-pr.sh
+++ b/.github/raise-pr.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Raise a PR and close any existing PRs where the title matches the prefix
+
+# Exit on error. Append || true if you expect an error.
+set -o errexit
+# Exit on error inside any functions or subshells.
+set -o errtrace
+# Do not allow use of undefined vars. Use ${VAR:-} to use an undefined VAR
+set -o nounset
+# Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
+set -o pipefail
+# Turn on traces, useful while debugging but commented out by default
+#set -o xtrace
+
+prefix="${1}"
+
+currentUser=$(gh api user | jq -r '.login')
+
+existing=$(gh pr list --search "author:$currentUser state:open" --json title,number | \
+  jq --arg t "$prefix" --raw-output '.[] | select(.title | contains($t)) | .number')
+
+gh pr create --fill-first --label "skip changelog"
+
+currentPr=$(gh pr view --json number | jq '.number')
+
+echo "$existing" | jq -r '.[].number' | xargs -I % -n 1 gh pr close % --comment "Superseded by #${currentPr}" --delete-branch
+
+echo "PR https://github.com/${GH_REPO}/pull/${currentPr} raised" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-major-go-deps.yaml
+++ b/.github/workflows/update-major-go-deps.yaml
@@ -1,0 +1,56 @@
+name: Update major Go dependency versions
+# https://github.com/golang/go/issues/40323
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 3 * * 1-5
+
+jobs:
+  go-major-dep-update:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        with:
+          token: "${{ secrets.RELEASE_TOKEN }}"
+
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+
+      - run: go install github.com/icholy/gomajor@v0.11.0
+
+      - run: |
+          {
+            echo 'new<<_GitHubActionsFileCommandDelimiter_'
+            gomajor list -major -json | jq --slurp --raw-output '[.[].Latest.Path] | join("\n * ")'
+            echo '_GitHubActionsFileCommandDelimiter_'
+          } >> $GITHUB_OUTPUT
+        id: deps
+
+      - run: gomajor get -major all
+
+      - run: go mod tidy
+
+      - run: echo "sum=$(md5sum ./go.mod | awk '{print $1}')" >> $GITHUB_OUTPUT
+        id: sum
+
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
+        id: commit
+        with:
+          create_branch: true
+          branch: "major-go-dep-update-${{ steps.sum.outputs.sum }}"
+          commit_message: |
+            Update major Go dependency versions
+
+            Update major version for:
+
+             * ${{ steps.deps.outputs.new }}
+
+      - name: Raise PR and close any old ones
+        if: steps.commit.outputs.changes_detected == 'true'
+        env:
+          GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
+          GH_REPO: "${{ github.repository }}"
+        run: .github/raise-pr.sh "Update major Go dependency versions"

--- a/.github/workflows/update-tools.yaml
+++ b/.github/workflows/update-tools.yaml
@@ -41,16 +41,5 @@ jobs:
         if: steps.commit.outputs.changes_detected == 'true'
         env:
           GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
-          REPO: "${{ github.repository }}"
-        run: |
-          currentUser=$(gh api user | jq -r '.login')
-
-          existing=$(gh pr list --repo "${REPO}" --search "'Update changie' author:$currentUser state:open" --json number)
-
-          gh pr create --repo "${REPO}" --fill-first --label "skip changelog"
-
-          currentPr=$(gh pr view --json number | jq '.number')
-
-          echo "$existing" | jq -r '.[].number' | xargs -I % -n 1 gh pr close % --repo "${REPO}" --comment "Superseded by #${currentPr}" --delete-branch
-
-          echo "PR https://github.com/${REPO}/pull/${currentPr} raised" >> $GITHUB_STEP_SUMMARY
+          GH_REPO: "${{ github.repository }}"
+        run: .github/raise-pr.sh "Update changie"


### PR DESCRIPTION
As Go and therefore Dependabot only supports updating the minor & patch versions of Go dependencies, we need to have a workflow which updates the major version of those dependencies.

Part of SUM-979